### PR TITLE
Added support for .Net Core

### DIFF
--- a/AltoHttp/GlobalSettings.cs
+++ b/AltoHttp/GlobalSettings.cs
@@ -22,8 +22,7 @@ namespace AltoHttp
 		{
 			ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
 			| SecurityProtocolType.Tls11
-			| SecurityProtocolType.Tls12
-			| SecurityProtocolType.Ssl3;
+			| SecurityProtocolType.Tls12;
             ServicePointManager.DefaultConnectionLimit = 1000;
 		}
 	}

--- a/AltoHttp/HttpDownloader.cs
+++ b/AltoHttp/HttpDownloader.cs
@@ -188,7 +188,7 @@ namespace AltoHttp
         public void Pause()
         {
             allowDownload = false;
-            downloadThread.Abort();
+            downloadThread.Interrupt();
         }
         /// <summary>
         /// Stops the download, deletes the downloaded file and resets the download


### PR DESCRIPTION
Hey aalitor!
You said that you don't really have any experience with .Net Core so I took the time to investigate some of the errors .net core would throw when using your library. Here are the things I changed:

SecurityProtocolType.Ssl3 isn't supported in .Net Core but not really necessary anyways nowadays

Thread.Abort() isn't supported in .Net Core so I used Thread.Interrupt()

Please note that I didn't test my changes yet but I'll test them and will edit this/make a new pull request to fix any errors that might occur